### PR TITLE
fixed mapfile bug in custom case metadata generator

### DIFF
--- a/src/script.sh
+++ b/src/script.sh
@@ -58,7 +58,7 @@ function make_case_metadata(){
     SAMPLESHEET=$1
 
     local SAMPLE_ARRAY
-    mapfile SAMPLE_ARRAY <<< "$(extract_samples "${SAMPLESHEET}")"
+    mapfile -t SAMPLE_ARRAY <<< "$(extract_samples "${SAMPLESHEET}")"
 
     echo "Sample_ID,Case_ID,Tumor_Type" > custom_case_metadata.csv
 


### PR DESCRIPTION
Fixed a bug that caused newlines to be injected after every sample ID, messing up the output format

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_ici_uploader/5)
<!-- Reviewable:end -->
